### PR TITLE
Correct and usable normal distribution sampler

### DIFF
--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -60,5 +60,5 @@ a uniform distribution)
 -}
 standardNormal : Generator Float
 standardNormal = Random.map2
-  (\u theta -> sqrt (-2 * logBase e (1 - u)) * cos theta
+  (\u theta -> sqrt (-2 * logBase e (1 - max 0 u)) * cos theta
   (float 0 1) (float 0 (2 * pi))

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -60,5 +60,5 @@ a uniform distribution)
 -}
 standardNormal : Generator Float
 standardNormal = Random.map2
-  (\u theta -> sqrt (-2 * logBase e (1 - u) * cos theta)
+  (\u theta -> sqrt (-2 * logBase e (1 - u) * cos theta))
   (Random.float 0 1) (Random.float 0 (2 * pi))

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -60,5 +60,5 @@ a uniform distribution)
 -}
 standardNormal : Generator Float
 standardNormal = Random.map2
-  (\u theta -> sqrt (-2 * logBase e (1 - u) * cos theta))
+  (\u theta -> sqrt (-2 * logBase e (1 - u)) * cos theta
   (float 0 1) (float 0 (2 * pi))

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -49,30 +49,16 @@ floatLessThan value =
 
 
 {-| Create a generator of floats that is normally distributed with
-given minimum, maximum, and standard deviation.
+given mean and standard deviation.
 -}
-normal : Float -> Float -> Float -> Generator Float
-normal start end standardDeviation =
-    let
-        normalDistribution mean stdDev x =
-            if stdDev == 0 then
-                x
-            else
-                let
-                    scale =
-                        1 / (stdDev * sqrt (2 * pi))
-
-                    exponent =
-                        ((x - mean) * (x - mean)) / (2 * stdDev * stdDev)
-                in
-                    scale * (e ^ -exponent)
-    in
-        map (normalDistribution ((end - start) / 2) standardDeviation) (float start end)
+normal : Float -> Float -> Generator Float
+normal mean stdDev = map (\u -> u * stdDev + mean) standardNormal
 
 
 {-| A generator that follows a standard normal distribution (as opposed to
 a uniform distribution)
 -}
 standardNormal : Generator Float
-standardNormal =
-    normal (toFloat minInt + 1) (toFloat maxInt) 1
+standardNormal = Random.map2
+  (\u theta -> sqrt (-2 * logBase e (1 - u) * cos theta)
+  (Random.float 0 1) (Random.float 0 (2 * pi))

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -61,4 +61,4 @@ a uniform distribution)
 standardNormal : Generator Float
 standardNormal = Random.map2
   (\u theta -> sqrt (-2 * logBase e (1 - u) * cos theta))
-  (Random.float 0 1) (Random.float 0 (2 * pi))
+  (float 0 1) (float 0 (2 * pi))


### PR DESCRIPTION
`normal` and `standardNormal` were severely broken based on sampling.
Not sure what algorithm was used, but this one is Box-Muller, which is very simple and proven.
The only disadvantage is that `normal` does not have bounded output, but this is acceptable for most uses of normally distributed variables, and has a more typical interface.
