### PR TITLE
Add `loop`

### DIFF
--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -441,7 +441,7 @@ to a list? Or maybe you need to track some information about what you just saw?
 machines](https://en.wikipedia.org/wiki/Finite-state_machine) to get a broader
 intuition about using state. I.e. You may want to create a type that describes
 four possible states, and then use Loop to transition between them as you
-consume characters.
+generate random values.
 
 -}
 type Step state a


### PR DESCRIPTION
Works similarly to
https://package.elm-lang.org/packages/elm/parser/latest/Parser#loop and allows
indefinitely looping generators without blowing the stack.

This also makes it easier to implement combinators like `chain` and `repeat` as described in #20 without any risky business.

I'm not entirely happy with the example usage I came up with, especially because it's really just `Random.list`... I originally wrote these functions as part of a slack conversation where @ryannhg was running into [issues with the stack being blown](https://ellie-app.com/6sgrtFZLRyja1) (try bumping up the `depth` on line 26). I think @joelq may also have some feedback on this.

---

Example implementations of `chain` and `repeat`:

```elm
chain : a -> List (a -> Generator a) -> Generator (List a)
chain seed generators =
    loop ( seed, [], generators ) chainHelp


chainHelp :
    ( a, List a, List (a -> Generator a) )
    -> Generator (Step ( a, List a, List (a -> Generator a) ) (List a))
chainHelp ( seed, acc, generators ) =
    case generators of
        [] ->
            constant (Done (List.reverse (seed :: acc)))

        generator :: rest ->
            map (\v -> Loop ( v, seed :: acc, rest )) (generator seed)
```

```elm
repeat : Int -> a -> (a -> Generator a) -> Generator (List a)
repeat depth seed toGenerator =
    loop ( depth, seed, [] ) (repeatHelp toGenerator)


repeatHelp :
    (a -> Generator a)
    -> ( Int, a, List a )
    -> Generator (Step ( Int, a, List a ) (List a))
repeatHelp toGenerator ( depth, seed, acc ) =
    if depth > 1 then
        map (\v -> Loop ( depth - 1, v, seed :: acc )) (toGenerator seed)

    else
        constant (Done (List.reverse (seed :: acc)))
```

(this is assuming I understand their intent based on the type signatures)
(`repeat` could also be `chain seed (List.repeat depth toGenerator)`)